### PR TITLE
Python requirement >= 3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aio-eapi"
-version = "0.6.0"
+version = "0.6.1"
 description = "Arista EOS API asyncio client"
 readme = "README.md"
 authors = ["Jeremy Schulman"]
@@ -9,7 +9,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.10"
+python = ">=3.8"
 httpx = "^0.23.3"
 
 


### PR DESCRIPTION
Fix #9 - change python requirement to >= 3.8