### PR TITLE
feat: add errors instance attribute to EapiCommandError

### DIFF
--- a/aioeapi/device.py
+++ b/aioeapi/device.py
@@ -218,7 +218,7 @@ class Device(httpx.AsyncClient):
 
         return cmd
 
-    async def jsonrpc_exec(self, jsonrpc: dict) -> list[Union[dict, AnyStr]]:
+    async def jsonrpc_exec(self, jsonrpc: dict) -> list[dict | AnyStr]:
         """
         Execute the JSON-RPC dictionary object.
 
@@ -247,7 +247,6 @@ class Device(httpx.AsyncClient):
         get_output = (lambda _r: _r["output"]) if ofmt == "text" else (lambda _r: _r)
 
         # if there are no errors then return the list of command results.
-
         if (err_data := body.get("error")) is None:
             return [get_output(cmd_res) for cmd_res in body["result"]]
 
@@ -257,16 +256,24 @@ class Device(httpx.AsyncClient):
         # not-executed).
         # ---------------------------------------------------------------------
 
+        # -------------------------- eAPI specification ----------------------
+        # On an error, no result object is present, only an error object, which
+        # is guaranteed to have the following attributes: code, messages, and
+        # data. Similar to the result object in the successful response, the
+        # data object is a list of objects corresponding to the results of all
+        # commands up to, and including, the failed command. If there was a an
+        # error before any commands were executed (e.g. bad credentials), data
+        # will be empty. The last object in the data array will always
+        # correspond to the failed command. The command failure details are
+        # always stored in the errors array.
+
         cmd_data = err_data["data"]
         len_data = len(cmd_data)
         err_at = len_data - 1
         err_msg = err_data["message"]
 
         raise EapiCommandError(
-            passed=[
-                get_output(cmd_data[cmd_i])
-                for cmd_i, cmd in enumerate(commands[:err_at])
-            ],
+            passed=[get_output(cmd_data[cmd_i]) for cmd_i, cmd in enumerate(commands[:err_at])],
             failed=commands[err_at]["cmd"],
             errors=cmd_data[err_at]["errors"],
             errmsg=err_msg,

--- a/aioeapi/device.py
+++ b/aioeapi/device.py
@@ -2,7 +2,9 @@
 # System Imports
 # -----------------------------------------------------------------------------
 
-from typing import Optional, List, Union, Dict, AnyStr
+from __future__ import annotations
+
+from typing import Optional, Union, AnyStr
 from socket import getservbyname
 
 # -----------------------------------------------------------------------------
@@ -118,7 +120,7 @@ class Device(httpx.AsyncClient):
     async def cli(
         self,
         command: Optional[AnyStr] = None,
-        commands: Optional[List[AnyStr]] = None,
+        commands: Optional[list[AnyStr]] = None,
         ofmt: Optional[str] = None,
         suppress_error: Optional[bool] = False,
         version: Optional[Union[int, str]] = "latest",
@@ -216,7 +218,7 @@ class Device(httpx.AsyncClient):
 
         return cmd
 
-    async def jsonrpc_exec(self, jsonrpc: dict) -> List[Union[Dict, AnyStr]]:
+    async def jsonrpc_exec(self, jsonrpc: dict) -> list[Union[dict, AnyStr]]:
         """
         Execute the JSON-RPC dictionary object.
 
@@ -265,9 +267,10 @@ class Device(httpx.AsyncClient):
                 get_output(cmd_data[cmd_i])
                 for cmd_i, cmd in enumerate(commands[:err_at])
             ],
-            failed=commands[err_at],
+            failed=commands[err_at]["cmd"],
+            errors=cmd_data[err_at]["errors"],
             errmsg=err_msg,
-            not_exec=commands[err_at + 1 :],
+            not_exec=commands[err_at + 1 :],  # noqa: E203
         )
 
     def config_session(self, name: str) -> SessionConfig:

--- a/aioeapi/device.py
+++ b/aioeapi/device.py
@@ -277,7 +277,7 @@ class Device(httpx.AsyncClient):
             failed=commands[err_at]["cmd"],
             errors=cmd_data[err_at]["errors"],
             errmsg=err_msg,
-            not_exec=commands[err_at + 1 :],  # noqa: E203
+            not_exec=commands[err_at + 1 :],
         )
 
     def config_session(self, name: str) -> SessionConfig:

--- a/aioeapi/errors.py
+++ b/aioeapi/errors.py
@@ -1,4 +1,8 @@
+from __future__ import annotations
+
 import httpx
+
+from typing import Union, Any
 
 
 class EapiCommandError(RuntimeError):
@@ -13,15 +17,24 @@ class EapiCommandError(RuntimeError):
     not_exec: List[str] - a list of commands that were not executed
     """
 
-    def __init__(self, failed: str, errmsg: str, passed, not_exec):
+    # pylint: disable=too-many-arguments
+    def __init__(
+        self,
+        failed: str,
+        errors: list[str],
+        errmsg: str,
+        passed: list[Union[str, dict[str, Any]]],
+        not_exec: list[dict[str, Any]],
+    ):
         """Initializer for the EapiCommandError exception"""
         self.failed = failed
+        self.errors = errors
         self.errmsg = errmsg
         self.passed = passed
         self.not_exec = not_exec
-        super(EapiCommandError, self).__init__()
+        super().__init__()
 
-    def __str__(self):
+    def __str__(self) -> str:
         """returns the error message associated with the exception"""
         return self.errmsg
 

--- a/aioeapi/errors.py
+++ b/aioeapi/errors.py
@@ -18,7 +18,6 @@ class EapiCommandError(RuntimeError):
     not_exec: list[str] - a list of commands that were not executed
     """
 
-    # pylint: disable=too-many-arguments
     def __init__(self, failed: str, errors: list[str], errmsg: str, passed: list[str | dict[str, Any]], not_exec: list[dict[str, Any]]):
         """Initializer for the EapiCommandError exception"""
         self.failed = failed

--- a/aioeapi/errors.py
+++ b/aioeapi/errors.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import httpx
 
-from typing import Union, Any
+from typing import Any
 
 
 class EapiCommandError(RuntimeError):
@@ -13,23 +13,17 @@ class EapiCommandError(RuntimeError):
     ----------
     failed: str - the failed command
     errmsg: str - a description of the failure reason
-    passed: List[dict] - a list of command results of the commands that passed
-    not_exec: List[str] - a list of commands that were not executed
+    errors: list[str] - the command failure details
+    passed: list[dict] - a list of command results of the commands that passed
+    not_exec: list[str] - a list of commands that were not executed
     """
 
     # pylint: disable=too-many-arguments
-    def __init__(
-        self,
-        failed: str,
-        errors: list[str],
-        errmsg: str,
-        passed: list[Union[str, dict[str, Any]]],
-        not_exec: list[dict[str, Any]],
-    ):
+    def __init__(self, failed: str, errors: list[str], errmsg: str, passed: list[str | dict[str, Any]], not_exec: list[dict[str, Any]]):
         """Initializer for the EapiCommandError exception"""
         self.failed = failed
-        self.errors = errors
         self.errmsg = errmsg
+        self.errors = errors
         self.passed = passed
         self.not_exec = not_exec
         super().__init__()


### PR DESCRIPTION
In order to implement https://github.com/arista-netdevops-community/anta/pull/437, we would need more information from aio-eapi when an eAPI request returns an error.

The following is an extract of the eAPI spec, defining the returned JSON payload when an error occurs:
``` json
{	
   "jsonrpc": "2.0",	
   "error": {
      "code": 1005,
      "message": "CLI command 2 of 5 'configure' failed: permission to run command denied",
      "data": [
         ,
         { "errors": [	
              "Authorization denied for command 'configure'"
         ] }	
      ]	
   },	
   "id": 1	
}
```

One can specify the `includeErrorDetail` param in the request to get more detailed information:
``` json
{	
   "jsonrpc": "2.0",	
   "error": {	
      "code": 1005,
      "message": "CLI command 2 of 5 'configure' failed: permission to run command denied",
      "data": {	
         "result": [	
            ,
            { "errors": [
                 "Authorization denied for command 'configure'"
            ] }
         ],
         "errorDetail": [
            { "index": 1,
              "code": 1005,
              "message": "permission to run command denied",
              "cmd": "configure" }
         ],	
   },	
   "id": 1
   }
}
```


Currently, the raised exception will look like this:
``` python
EapiCommandError(
                passed=[],
                failed="show hardware counter drop",
                errmsg="CLI command 1 of 1 'show hardware counter drop' failed: invalid command",
                not_exec=[],
            )
```
This PR is to add an extra instance attribute to be able to access more information about the error:
``` python
EapiCommandError(
                passed=[],
                failed="show hardware counter drop",
                errors=["Unavailable command (not supported on this hardware platform) (at token 2: 'counter')"],
                errmsg="CLI command 1 of 1 'show hardware counter drop' failed: invalid command",
                not_exec=[],
            )
```
This PR does not implement the usage of the `includeErrorDetail` eAPI param.