### PR TITLE
chore: remove httpx upper bounds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.8"
-httpx = "^0.23.3"
+httpx = ">=0.23.3"
 
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
This PR removes httpx upper bounds in aio-eapi dependencies.
Setting upper bounds in libraries dependencies versions used in other libraries or applications that needs to use the latest dependencies versions (https://iscinumpy.dev/post/bound-version-constraints/).
In our case, httpx has Python 3.12 support since 0.25.1 and we are also interested in logging enhancement introduced in 0.24.0.

https://github.com/arista-netdevops-community/anta/issues/645